### PR TITLE
Remove explicit path to which

### DIFF
--- a/src/testing/common/database.py
+++ b/src/testing/common/database.py
@@ -300,7 +300,7 @@ def get_path_of(name):
     if os.name == 'nt':
         which = 'where'
     else:
-        which = '/usr/bin/which'
+        which = 'which'
     path = subprocess.Popen([which, name],
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE).communicate()[0]


### PR DESCRIPTION
It is possible that on *nix systems, `which` program isn't located in `/usr/bin/which`. Thus, just use `which` and assume that it's in `PATH`. At least on NixOS, `which` is located in a complex path in nix store, thus the path to it cannot be hardcoded.

Is this ok? Are there cases when the path to `which` should be hardcoded?