### PR TITLE
Fix launch when using cache_initialized_db without init_handler

### DIFF
--- a/src/testing/common/database.py
+++ b/src/testing/common/database.py
@@ -48,7 +48,7 @@ class DatabaseFactory(object):
                         self.cache.terminate()
             else:
                 settings_noautostart = copy.deepcopy(self.settings)
-                settings_noautostart.update({"autostart": 0})
+                settings_noautostart.update({"auto_start": 0})
                 self.cache = self.target_class(**settings_noautostart)
                 self.cache.setup()
             self.settings['copy_data_from'] = self.cache.get_data_directory()


### PR DESCRIPTION
after the latest release i started seeing these errors when running my postgres tests
```
RuntimeError: *** failed to launch Postgresql ***
FATAL:  lock file "postmaster.pid" already exists
HINT:  Is another postmaster (PID 28423) running in data directory "/tmp/tmp47fn20ka/data"?
```

my setup uses the factory as such:
```
POSTGRESQL_FACTORY = testing.postgresql.PostgresqlFactory(cache_initialized_db=True)
```
and at the start of every test
```
psql = POSTGRESQL_FACTORY()
```

I tracked this down to the `auto_start` variable being named incorrectly in a recent PR, which caused the `setup()` method to be called twice, leading to this error.