### PR TITLE
Fix a typo in parameter name for DB autostart

### DIFF
--- a/src/testing/common/database.py
+++ b/src/testing/common/database.py
@@ -48,7 +48,7 @@ class DatabaseFactory(object):
                         self.cache.terminate()
             else:
                 settings_noautostart = copy.deepcopy(self.settings)
-                settings_noautostart.update({"autostart": 0})
+                settings_noautostart.update({"auto_start": 0})
                 self.cache = self.target_class(**settings_noautostart)
                 self.cache.setup()
             self.settings['copy_data_from'] = self.cache.get_data_directory()


### PR DESCRIPTION
Commit 3fd2ca0 brings a typo - `autostart` keyword was used instead
of `auto_start`. So autostart was not disabled and this caused
issues like https://github.com/tk0miya/testing.common.database/issues/16
This commit fixes it.